### PR TITLE
Corrected python requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     },
 
     install_requires=[required],
-    python_requires=">=3.10",
+    python_requires=">=3.6",
     include_package_data=True,
 )


### PR DESCRIPTION
The setup file mentions that Python >= 3.10 is required, but Python 3.6 is sufficient after testing the library with vermin. It's usage is decreasing steadily, but still used by a lot of Python devs.

[minimum_version_test.txt](https://github.com/godamartonaron/GODA_pyPPG/files/13266245/minimum_version_test.txt)

(not covered by this request, but also an option) Might be useful to check the requirements file with ">=" rather than specific versions and move them to the project toml file instead of old requirements.txt files